### PR TITLE
松原和也のブログのリンク先が最新記事のページになっていたので、トップページをリンク先に変更

### DIFF
--- a/2015.md
+++ b/2015.md
@@ -60,6 +60,6 @@ permalink: /2015/
 * 薮兼 智英 <small>実行委員長</small>
 * 佐々木 宣介 <small>所属 [県立広島大学](http://www.pu-hiroshima.ac.jp/)</small> [<i class="fa fa-facebook"></i>](https://www.facebook.com/profile.php?id=100005606825558)
 * 曽根 壮大 [<i class="fa fa-link"></i>](http://soudai1025.blogspot.jp/) [<i class="fa fa-facebook"></i>](https://www.facebook.com/soudai.sone) [<i class="fa fa-twitter"></i>](http://twitter.com/soudai1025) [<i class="fa fa-github"></i>](https://github.com/soudai)
-* 松原 和也 [<i class="fa fa-link"></i>](http://106n.net/toro/blog/ltdd09-hiroshima-advent-2014-8/) [<i class="fa fa-facebook"></i>](https://www.facebook.com/KzMatsubara?fref=ts) [<i class="fa fa-twitter"></i>](http://twitter.com/Toro_kun) [<i class="fa fa-github"></i>](http://github.com/Torokun)
+* 松原 和也 [<i class="fa fa-link"></i>](http://106n.net/toro/blog/) [<i class="fa fa-facebook"></i>](https://www.facebook.com/KzMatsubara?fref=ts) [<i class="fa fa-twitter"></i>](http://twitter.com/Toro_kun) [<i class="fa fa-github"></i>](http://github.com/Torokun)
 * 池田 道弘 [<i class="fa fa-facebook"></i>](https://www.facebook.com/ikeda.shogouki)
 * 火村 智彦 [<i class="fa fa-link"></i>](http://eiel.info/)[<i class="fa fa-facebook"></i>](https://www.facebook.com/eielh) [<i class="fa fa-twitter"></i>](https://twitter.com/eielh) [<i class="fa fa-github"></i>](https://github.com/eiel)


### PR DESCRIPTION
松原和也のブログのリンク先が最新記事のページになっていたので、トップページをリンク先に変更
