### PR TITLE
Twitterハッシュタグのリンク先がosh2015だったのをosh2016に修正

### DIFF
--- a/_includes/2016_abstract.html
+++ b/_includes/2016_abstract.html
@@ -39,7 +39,7 @@
   </ul>
 
   <h2>Twitterのハッシュタグ</h2>
-  <a href="https://twitter.com/search?q=%23osh2015&src=typd">#osh2016</a>
+  <a href="https://twitter.com/search?q=%23osh2016&src=typd">#osh2016</a>
 
   <h2>URL</h2>
   http://osh-web.github.io/2016/


### PR DESCRIPTION
レビューお願いします