### PR TITLE
fix: スピーカー情報の名前を更新

### DIFF
--- a/src/resources/2025/speakers.js
+++ b/src/resources/2025/speakers.js
@@ -86,7 +86,7 @@ export const sankyo: Speaker = {
 
 export const gr1m0h: Speaker = {
   furi: '',
-  name: 'Wataru Tsuda',
+  name: 'Wataru Tsuda/gr1m0h様',
   key: 'gr1m0h',
   title: [],
   description:


### PR DESCRIPTION
gr1m0hさんの依頼によりスピーカーの氏名を変更しました。

- Wataru Tsudaの名前を'Wataru Tsuda/gr1m0h様'に変更